### PR TITLE
Add format support

### DIFF
--- a/src/__tests__/faker.test.ts
+++ b/src/__tests__/faker.test.ts
@@ -25,6 +25,9 @@ describe("faker", () => {
         system: {
           mimeType: () => "File",
         },
+        date: {
+          past: () => new Date(2012, 2, 6, 6, 34, 23, 10),
+        },
       };
     });
   });

--- a/src/__tests__/faker.test.ts
+++ b/src/__tests__/faker.test.ts
@@ -30,6 +30,9 @@ describe("faker", () => {
         },
         internet: {
           url: () => "https://www.google.com",
+          ip: () => "127.0.0.1",
+          ipv6: () => "::1",
+          email: () => "john@example.com",
         },
       };
     });

--- a/src/__tests__/faker.test.ts
+++ b/src/__tests__/faker.test.ts
@@ -28,6 +28,9 @@ describe("faker", () => {
         date: {
           past: () => new Date(2012, 2, 6, 6, 34, 23, 10),
         },
+        internet: {
+          url: () => "https://www.google.com",
+        },
       };
     });
   });

--- a/src/__tests__/mock-data/fakerMocks.ts
+++ b/src/__tests__/mock-data/fakerMocks.ts
@@ -128,5 +128,8 @@ export const fakerExpectedValue = {
     doorNumber: 10,
     street: "HuaFu Avenue",
     website: "https://www.google.com",
+    ipv4: "127.0.0.1",
+    ipv6: "::1",
+    email: "john@example.com",
   },
 };

--- a/src/__tests__/mock-data/fakerMocks.ts
+++ b/src/__tests__/mock-data/fakerMocks.ts
@@ -2,6 +2,8 @@ export const fakerExpectedValue = {
   BookDetailVo: {
     authorName: "Tony",
     createdDate: 19920010,
+    createdTime: "06:34:23.010Z",
+    updatedAt: "2012-03-06T06:34:23.010Z",
     attachment: {
       team: "string words",
       schedules: [
@@ -9,6 +11,7 @@ export const fakerExpectedValue = {
           {
             price: "string words",
             address: "string words",
+            createdAt: "2012-03-06",
           },
         ],
       ],
@@ -21,6 +24,7 @@ export const fakerExpectedValue = {
         {
           price: "string words",
           address: "string words",
+          createdAt: "2012-03-06",
         },
       ],
     ],
@@ -28,6 +32,7 @@ export const fakerExpectedValue = {
   BookVO: {
     price: "string words",
     address: "string words",
+    createdAt: "2012-03-06",
   },
   InputStream: {},
   Resource: {
@@ -61,6 +66,8 @@ export const fakerExpectedValue = {
     attachment: {
       authorName: "Tony",
       createdDate: 19920010,
+      createdTime: "06:34:23.010Z",
+      updatedAt: "2012-03-06T06:34:23.010Z",
       attachment: {
         team: "string words",
         schedules: [
@@ -68,6 +75,7 @@ export const fakerExpectedValue = {
             {
               price: "string words",
               address: "string words",
+              createdAt: "2012-03-06",
             },
           ],
         ],
@@ -87,6 +95,8 @@ export const fakerExpectedValue = {
       attachment: {
         authorName: "Tony",
         createdDate: 19920010,
+        createdTime: "06:34:23.010Z",
+        updatedAt: "2012-03-06T06:34:23.010Z",
         attachment: {
           team: "string words",
           schedules: [
@@ -94,6 +104,7 @@ export const fakerExpectedValue = {
               {
                 price: "string words",
                 address: "string words",
+                createdAt: "2012-03-06",
               },
             ],
           ],
@@ -115,6 +126,6 @@ export const fakerExpectedValue = {
   Location: {
     address: ["test", 123],
     doorNumber: 10,
-    street: "HuaFu Avenue"
+    street: "HuaFu Avenue",
   },
 };

--- a/src/__tests__/mock-data/fakerMocks.ts
+++ b/src/__tests__/mock-data/fakerMocks.ts
@@ -127,5 +127,6 @@ export const fakerExpectedValue = {
     address: ["test", 123],
     doorNumber: 10,
     street: "HuaFu Avenue",
+    website: "https://www.google.com",
   },
 };

--- a/src/__tests__/mock-data/mockDefinitiions.ts
+++ b/src/__tests__/mock-data/mockDefinitiions.ts
@@ -11,6 +11,14 @@ export const mockDefinitions = {
         format: "int64",
         example: 19920010,
       },
+      createdTime: {
+        type: "string",
+        format: "time",
+      },
+      updatedAt: {
+        type: "string",
+        format: "date-time",
+      },
       attachment: {
         $ref: "#/definitions/ScheduleVO",
       },
@@ -43,6 +51,10 @@ export const mockDefinitions = {
       },
       address: {
         type: "string",
+      },
+      createdAt: {
+        type: "string",
+        format: "date",
       },
     },
     title: "BookVO",

--- a/src/__tests__/mock-data/mockDefinitiions.ts
+++ b/src/__tests__/mock-data/mockDefinitiions.ts
@@ -227,6 +227,10 @@ export const mockDefinitions = {
         type: "string",
         enum: ["HuaFu Avenue"],
       },
+      website: {
+        type: "string",
+        format: "uri",
+      },
     },
   },
 } as any;

--- a/src/__tests__/mock-data/mockDefinitiions.ts
+++ b/src/__tests__/mock-data/mockDefinitiions.ts
@@ -231,6 +231,18 @@ export const mockDefinitions = {
         type: "string",
         format: "uri",
       },
+      ipv4: {
+        type: "string",
+        format: "ipv4",
+      },
+      ipv6: {
+        type: "string",
+        format: "ipv6",
+      },
+      email: {
+        type: "string",
+        format: "email",
+      },
     },
   },
 } as any;

--- a/src/__tests__/mock-data/traverseMocks.ts
+++ b/src/__tests__/mock-data/traverseMocks.ts
@@ -406,6 +406,10 @@ export const traverseExpectedValue = {
         type: "string",
         enum: ["HuaFu Avenue"],
       },
+      website: {
+        type: "string",
+        format: "uri",
+      },
     },
   },
 };

--- a/src/__tests__/mock-data/traverseMocks.ts
+++ b/src/__tests__/mock-data/traverseMocks.ts
@@ -11,6 +11,14 @@ export const traverseExpectedValue = {
         format: "int64",
         example: 19920010,
       },
+      createdTime: {
+        type: "string",
+        format: "time",
+      },
+      updatedAt: {
+        type: "string",
+        format: "date-time",
+      },
       attachment: {
         type: "object",
         properties: {
@@ -28,6 +36,10 @@ export const traverseExpectedValue = {
                     type: "string",
                   },
                   address: {
+                    type: "string",
+                  },
+                  createdAt: {
+                    format: "date",
                     type: "string",
                   },
                 },
@@ -60,6 +72,10 @@ export const traverseExpectedValue = {
               address: {
                 type: "string",
               },
+              createdAt: {
+                format: "date",
+                type: "string",
+              },
             },
             title: "BookVO",
           },
@@ -75,6 +91,10 @@ export const traverseExpectedValue = {
         type: "string",
       },
       address: {
+        type: "string",
+      },
+      createdAt: {
+        format: "date",
         type: "string",
       },
     },
@@ -192,6 +212,14 @@ export const traverseExpectedValue = {
             format: "int64",
             example: 19920010,
           },
+          createdTime: {
+            type: "string",
+            format: "time",
+          },
+          updatedAt: {
+            format: "date-time",
+            type: "string",
+          },
           attachment: {
             type: "object",
             properties: {
@@ -209,6 +237,10 @@ export const traverseExpectedValue = {
                         type: "string",
                       },
                       address: {
+                        type: "string",
+                      },
+                      createdAt: {
+                        format: "date",
                         type: "string",
                       },
                     },
@@ -268,6 +300,14 @@ export const traverseExpectedValue = {
                 format: "int64",
                 example: 19920010,
               },
+              createdTime: {
+                type: "string",
+                format: "time",
+              },
+              updatedAt: {
+                format: "date-time",
+                type: "string",
+              },
               attachment: {
                 type: "object",
                 properties: {
@@ -285,6 +325,10 @@ export const traverseExpectedValue = {
                             type: "string",
                           },
                           address: {
+                            type: "string",
+                          },
+                          createdAt: {
+                            format: "date",
                             type: "string",
                           },
                         },

--- a/src/__tests__/mock-data/traverseMocks.ts
+++ b/src/__tests__/mock-data/traverseMocks.ts
@@ -410,6 +410,18 @@ export const traverseExpectedValue = {
         type: "string",
         format: "uri",
       },
+      ipv4: {
+        type: "string",
+        format: "ipv4",
+      },
+      ipv6: {
+        type: "string",
+        format: "ipv6",
+      },
+      email: {
+        type: "string",
+        format: "email",
+      },
     },
   },
 };

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -1,6 +1,14 @@
 import { Reference, Response, Schema, Spec } from "swagger-schema-official";
 import { get, isArray, map, mapValues } from "lodash";
-import { booleanGenerator, fileGenerator, numberGenerator, stringGenerator } from "./generators";
+import {
+  booleanGenerator,
+  fileGenerator,
+  numberGenerator,
+  stringGenerator,
+  dateGenerator,
+  timeGenerator,
+  dateTimeGenerator,
+} from "./generators";
 import { pickRefKey } from "./utils";
 import { Traverse } from "./traverse";
 
@@ -74,6 +82,15 @@ const toFakeProp = (schema: Schema) => {
     case "boolean":
       return booleanGenerator();
     case "string":
+      if (schema.format) {
+        if (schema.format === "date") {
+          return dateGenerator();
+        } else if (schema.format === "time") {
+          return timeGenerator();
+        } else if (schema.format === "date-time") {
+          return dateTimeGenerator();
+        }
+      }
       return stringGenerator(schema.enum);
     case "number":
     case "integer":

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -39,14 +39,14 @@ export const toFakeObj = (schema: Schema = {}): any => {
   if (schema.properties) {
     results = {
       ...results,
-      ...getFakeProperties(schema.properties),
+      ...getFakeProperties(schema.properties as Schema),
     };
   }
 
   if (schema.additionalProperties) {
     results = {
       ...results,
-      ...getFakeProperties(schema.additionalProperties),
+      ...getFakeProperties(schema.additionalProperties as Schema),
     };
   }
 

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -9,6 +9,9 @@ import {
   timeGenerator,
   dateTimeGenerator,
   urlGenerator,
+  ipv4Generator,
+  ipv6Generator,
+  emailGenerator,
 } from "./generators";
 import { pickRefKey } from "./utils";
 import { Traverse } from "./traverse";
@@ -91,6 +94,12 @@ const toFakeProp = (schema: Schema) => {
         return dateTimeGenerator();
       } else if (schema.format === "uri") {
         return urlGenerator();
+      } else if (schema.format === "ipv4") {
+        return ipv4Generator();
+      } else if (schema.format === "ipv6") {
+        return ipv6Generator();
+      } else if (schema.format === "email") {
+        return emailGenerator();
       }
       return stringGenerator(schema.enum);
     case "number":

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -8,6 +8,7 @@ import {
   dateGenerator,
   timeGenerator,
   dateTimeGenerator,
+  urlGenerator,
 } from "./generators";
 import { pickRefKey } from "./utils";
 import { Traverse } from "./traverse";
@@ -82,14 +83,14 @@ const toFakeProp = (schema: Schema) => {
     case "boolean":
       return booleanGenerator();
     case "string":
-      if (schema.format) {
-        if (schema.format === "date") {
-          return dateGenerator();
-        } else if (schema.format === "time") {
-          return timeGenerator();
-        } else if (schema.format === "date-time") {
-          return dateTimeGenerator();
-        }
+      if (schema.format === "date") {
+        return dateGenerator();
+      } else if (schema.format === "time") {
+        return timeGenerator();
+      } else if (schema.format === "date-time") {
+        return dateTimeGenerator();
+      } else if (schema.format === "uri") {
+        return urlGenerator();
       }
       return stringGenerator(schema.enum);
     case "number":

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -9,3 +9,7 @@ export const numberGenerator = (max?: number, min?: number) =>
     max,
   });
 export const fileGenerator = () => faker.system.mimeType();
+
+export const dateTimeGenerator = () => faker.date.past().toISOString();
+export const dateGenerator = () => dateTimeGenerator().slice(0, 10);
+export const timeGenerator = () => dateTimeGenerator().slice(11);

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -13,3 +13,4 @@ export const fileGenerator = () => faker.system.mimeType();
 export const dateTimeGenerator = () => faker.date.past().toISOString();
 export const dateGenerator = () => dateTimeGenerator().slice(0, 10);
 export const timeGenerator = () => dateTimeGenerator().slice(11);
+export const urlGenerator = () => faker.internet.url();

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -14,3 +14,6 @@ export const dateTimeGenerator = () => faker.date.past().toISOString();
 export const dateGenerator = () => dateTimeGenerator().slice(0, 10);
 export const timeGenerator = () => dateTimeGenerator().slice(11);
 export const urlGenerator = () => faker.internet.url();
+export const ipv4Generator = () => faker.internet.ip();
+export const ipv6Generator = () => faker.internet.ipv6();
+export const emailGenerator = () => faker.internet.email();

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -29,7 +29,7 @@ export class Traverse {
     if (definition.additionalProperties) {
       return {
         ...definition,
-        properties: this.handleRef(definition.additionalProperties),
+        properties: this.handleRef(definition.additionalProperties as Schema),
       };
     }
 


### PR DESCRIPTION
@reeli this adds support for `format` for string types on JSON schema, based on https://docs.opis.io/json-schema/1.x/formats.html